### PR TITLE
Drone Health Monitor Node

### DIFF
--- a/drone_health_monitor/msg/DroneHealth.msg
+++ b/drone_health_monitor/msg/DroneHealth.msg
@@ -1,53 +1,10 @@
 Header header
 
-# System Status
-bool system_ok
-string system_mode
-string[] active_errors
-string[] active_warnings
-
-# Connection Status
-bool fcu_connected
-time last_heartbeat
-float32 connection_quality
-
-# Flight status
-bool armed
-string flight_mode
-float32 flight_time
-
-# Battery status
-float32 voltage
-float32 current
-float32 remaining_percentage
-float32 remaining_time
-uint8 battery_status
-string power_status
-
-# Position & Navigation
+bool is_armed
+bool is_connected
 bool gps_ok
-uint8 gps_satellites
-float32 gps_hdop
-bool position_ok
-float32[3] position_xyz
-float32[3] velocity_xyz
-float32[3] attitude_rpy
-float32 position_accuracy
-float32 altitude_agl
-
-# Mission Status
-string mission_state
-float32 mission_progress
-string current_waypoint
-uint32 waypoints_remaining
-
-# Performance Metrics
-float32 cpu_usage
-float32 memory_usage
-float32 disk_usage
-float32 network_bandwidth
-float32 loop_rate
-
-# Custom Fields
-string[] custom_status_names
-float32[] custom_status_values
+bool imu_ok
+float32 battery_percent
+float32 battery_voltage
+float32 temperature
+string flight_mode

--- a/drone_health_monitor/msg/DroneHealth.msg
+++ b/drone_health_monitor/msg/DroneHealth.msg
@@ -3,8 +3,7 @@ Header header
 bool is_armed
 bool is_connected
 bool gps_ok
-bool imu_ok
 float32 battery_percent
 float32 battery_voltage
-float32 temperature
+float64 temperature
 string flight_mode

--- a/drone_health_monitor/src/drone_health_monitor_node.py
+++ b/drone_health_monitor/src/drone_health_monitor_node.py
@@ -3,6 +3,7 @@
 import rospy
 from drone_health_monitor.msg import DroneHealth
 from mavros_msgs.msg import State
+from sensor_msgs.msg import NavSatFix, BatteryState
 
 class DroneHealthMonitor():
     def __init__(self):
@@ -15,14 +16,24 @@ class DroneHealthMonitor():
         self.drone_health = DroneHealth()
         
         rospy.Subscriber("/mavros/state", State, self.state_callback)
+        rospy.Subscriber("/mavros/global_position/raw/fix", NavSatFix, self.global_position_callback)
+        rospy.Subscriber("/mavros/battery", BatteryState, self.battery_state_callback)
 
     def state_callback(self, msg: State) -> None:
-        self.drone_health.system_ok = msg.connected
-        self.drone_health.system_mode = msg.mode
-        self.drone_health.fcu_connected = msg.connected
+        self.drone_health.header = msg.header
+        self.drone_health.is_armed = msg.armed
+        self.drone_health.is_connected = msg.connected
+        self.drone_health.flight_mode = msg.mode
+
+    def global_position_callback(self, msg: NavSatFix):
+        self.drone_health.gps_ok = msg.status.status >= msg.status.STATUS_FIX
+
+    def battery_state_callback(self, msg: BatteryState):
+        self.drone_health.battery_percent = msg.percentage
+        self.drone_health.battery_voltage = msg.voltage
 
     def display_drone_health(self) -> None:
-        rospy.loginfo(f"Drone FCU Connected: { self.drone_health.fcu_connected }")
+        rospy.loginfo(f"Drone Battery Connected: { self.drone_health.battery_percent }")
 
     def start(self) -> None:
         while not rospy.is_shutdown():

--- a/drone_health_monitor/src/drone_health_monitor_node.py
+++ b/drone_health_monitor/src/drone_health_monitor_node.py
@@ -3,21 +3,25 @@
 import rospy
 from drone_health_monitor.msg import DroneHealth
 from mavros_msgs.msg import State
-from sensor_msgs.msg import NavSatFix, BatteryState
+from sensor_msgs.msg import NavSatFix, BatteryState, Temperature
 
 class DroneHealthMonitor():
     def __init__(self):
         rospy.init_node("drone_health_monitor")
-
-        # Print at 1 Hz looped
-        self.rate = 1.0
-        self.loop_rate = rospy.Rate(self.rate)
 
         self.drone_health = DroneHealth()
         
         rospy.Subscriber("/mavros/state", State, self.state_callback)
         rospy.Subscriber("/mavros/global_position/raw/fix", NavSatFix, self.global_position_callback)
         rospy.Subscriber("/mavros/battery", BatteryState, self.battery_state_callback)
+        rospy.Subscriber("/mavros/imu/temperature", Temperature, self.imu_temperature_callback)
+
+        # Publisher to /drone_health
+        self.pub = rospy.Publisher("/drone_health", DroneHealth, queue_size=10)
+
+        # Print at 10 Hz looped
+        self.rate = 10
+        self.loop_rate = rospy.Rate(self.rate)
 
     def state_callback(self, msg: State) -> None:
         self.drone_health.header = msg.header
@@ -32,12 +36,17 @@ class DroneHealthMonitor():
         self.drone_health.battery_percent = msg.percentage
         self.drone_health.battery_voltage = msg.voltage
 
+    def imu_temperature_callback(self, msg: Temperature):
+        self.drone_health.temperature = msg.temperature
+
+    # This is for debugging while developing
     def display_drone_health(self) -> None:
-        rospy.loginfo(f"Drone Battery Connected: { self.drone_health.battery_percent }")
+        rospy.loginfo(f"{ self.drone_health }")
 
     def start(self) -> None:
         while not rospy.is_shutdown():
-            self.display_drone_health()
+            self.drone_health.header.stamp = rospy.Time.now()
+            self.pub.publish(self.drone_health)
             self.loop_rate.sleep()
 
 


### PR DESCRIPTION
Publishes DroneHealth message to /drone_health topic.

This can be used to monitor the current drone state and execute decisions based on them. For example, a faulty GPS or battery percentage may be grounds for grounding the flight until further notice. Should be used in state machines or missions managers.